### PR TITLE
Fix Wagner-Whitin Algorithm to Handle Zero-Demand Periods Correctly

### DIFF
--- a/src/stockpyl/wagner_whitin.py
+++ b/src/stockpyl/wagner_whitin.py
@@ -134,7 +134,7 @@ def wagner_whitin(num_periods, holding_cost, fixed_cost, demand, purchase_cost=0
 		best_cost = BIG_FLOAT
 		for ss in range(t+1, num_periods+2):
 			# Calculate cost if next order is in period ss.
-			cost = fixed_cost[t]
+			cost = fixed_cost[t] * (sum(demand[i] for i in range(t, ss)) > 0) # 0 fixed/setup cost if demand is 0
 			for i in range(t, ss):
 				cost += purchase_cost[t] * demand[i] + holding_cost[t] * (i - t) * demand[i]
 			cost += theta[ss]


### PR DESCRIPTION
### Description
The current `wagner_whitin` function incorrectly applies the fixed/setup cost \( K_t \) when no demand exists between \( t \) and \( s-1 \), leading to suboptimal solutions (e.g., cost of 145 vs. optimal 131 for `demands = [0, 0, 0, 0, 0, 7]`, `fixed_costs = [110, 108, 110, 120, 125, 134]`, `holding_costs = [1, 1, 1, 1, 1, 1]`).

### Changes
Modified one line in the cost calculation:
- From: `cost = fixed_cost[t]`
- To: `cost = fixed_cost[t] * (sum(demand[i] for i in range(t, ss)) > 0)`

This excludes \( K_t \) when demand from \( t \) to \( ss-1 \) is zero, ensuring the algorithm skips unnecessary production.

### Steps to Test
Run with:
- `demands = [0, 0, 0, 0, 0, 7]`
- `fixed_costs = [110, 108, 110, 120, 125, 134]`
- `holding_costs = [1, 1, 1, 1, 1, 1]`
- `purchase_costs = [0, 0, 0, 0, 0, 0]`

Expected: `total_cost = 131.0`, `order_quantities = [0, 0, 0, 7, 0, 0, 0]`, consistent with manual grid search and another WW implementation ([gist](https://gist.github.com/tommyod/7d3ee88b7c08fadab6de1ea1e615a925)).